### PR TITLE
remove the type of the elements of this combo box

### DIFF
--- a/src/me/drton/flightplot/FlightPlot.java
+++ b/src/me/drton/flightplot/FlightPlot.java
@@ -93,7 +93,7 @@ public class FlightPlot {
     private JButton removeProcessorButton;
     private JButton openLogButton;
     private JButton fieldsListButton;
-    private JComboBox<Preset> presetComboBox;
+    private JComboBox presetComboBox;
     private List<Preset> presetsList = new ArrayList<Preset>();
     private JButton deletePresetButton;
     private JButton logInfoButton;


### PR DESCRIPTION
When I compile flightplot, I have some problems with this statement like below
"javax.swing.JComboBox does not take parameters"

In order to solve this problem, I remove the type of the elements of this combo box.

```
stmoon:~/Project/PX4/FlightPlot$ ant
Buildfile: /home/stmoon/Project/PX4/FlightPlot/build.xml

make_dirs:
    [mkdir] Created dir: /home/stmoon/Project/PX4/FlightPlot/out/production/FlightPlot

compile:
   [javac2] Compiling 108 source files to /home/stmoon/Project/PX4/FlightPlot/out/production/FlightPlot
   [javac2] /home/stmoon/Project/PX4/FlightPlot/src/me/drton/flightplot/FlightPlot.java:96: type javax.swing.JComboBox does not take parameters
   [javac2]     private JComboBox<Preset> presetComboBox;
   [javac2]                      ^
   [javac2] Note: Some input files use unchecked or unsafe operations.
   [javac2] Note: Recompile with -Xlint:unchecked for details.
   [javac2] 1 error

BUILD FAILED
/home/stmoon/Project/PX4/FlightPlot/build.xml:24: Compile failed; see the compiler error output for details.

Total time: 1 second
```

