### PR TITLE
initial travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  #- oraclejdk9 #TODO: fix java9
+  - openjdk7
+  - openjdk8
+  #- openjdk9 #TODO: fix java9
+
+git:
+  depth: 2000
+  submodules: true
+
+cache:
+  ccache: true
+
+script:
+  - ant clean
+  - ant zip_artifacts
+
+deploy:
+  provider: releases
+  file: out/production/*.zip 
+  skip_cleanup: true
+  on:
+    tags: true
+


### PR DESCRIPTION
Moving builds to travis-ci to get rid of sitl01 jenkins.

On the firmware side everything is moving to http://ci.px4.io:8080/blue/organizations/jenkins/.