### PR TITLE
Make EulerFromQuaternion processor defaults suitable for PX4

### DIFF
--- a/src/me/drton/flightplot/processors/EulerFromQuaternion.java
+++ b/src/me/drton/flightplot/processors/EulerFromQuaternion.java
@@ -17,7 +17,7 @@ public class EulerFromQuaternion extends PlotProcessor {
     @Override
     public Map<String, Object> getDefaultParameters() {
         Map<String, Object> params = new HashMap<String, Object>();
-        params.put("Fields", "ATT.Q0 ATT.Q1 ATT.Q2 ATT.Q3");
+        params.put("Fields", "vehicle_attitude_0.q[0] vehicle_attitude_0.q[1] vehicle_attitude_0.q[2] vehicle_attitude_0.q[3]");
         params.put("Show", "RPY");
         params.put("Scale", 1.0);
         return params;


### PR DESCRIPTION
EulerFromQuaternion processor is usable when you want to look at the vehicle actual pitch/roll/yaw estimations plots.

This PR changes the "fields" setting so it can be used with PX4 by default.

<img width="1024" alt="Снимок экрана 2019-05-11 в 10 26 16" src="https://user-images.githubusercontent.com/1683279/57566599-4425c680-73d7-11e9-85bb-8e2592d4465c.png">